### PR TITLE
Fix controlled component behavior

### DIFF
--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -93,7 +93,7 @@ var Tokenizer = function (_Component) {
     value: function componentWillReceiveProps(nextProps) {
       var update = {};
       if (nextProps.value !== this.props.value) {
-        update = this.getStateFromProps(nextProps);
+        update.selected = this.getStateFromProps(nextProps);
       }
       this.setState(update);
     }

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -183,9 +183,9 @@ export default class Tokenizer extends Component {
   }
 
   componentWillReceiveProps( nextProps ) {
-    let update = {};
+    const update = {};
     if ( nextProps.value !== this.props.value ) {
-      update = this.getStateFromProps( nextProps );
+      update.selected = this.getStateFromProps( nextProps );
     }
     this.setState( update );
   }


### PR DESCRIPTION
Fixed the incorrect behavior of no filters being shown if the `value`
prop is given.
