### PR TITLE
Fix react15 warn

### DIFF
--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -14,6 +14,10 @@ var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _token = require('./token');
 
 var _token2 = _interopRequireDefault(_token);
@@ -382,7 +386,7 @@ Tokenizer.propTypes = {
    *       }
    *     ]
    */
-  options: _react.PropTypes.array,
+  options: _propTypes2.default.array,
 
   /**
    * An object containing custom class names for child elements. Useful for
@@ -397,7 +401,7 @@ Tokenizer.propTypes = {
    *       listItem: 'filter-tokenizer-list__item'
    *     }
    */
-  customClasses: _react.PropTypes.object,
+  customClasses: _propTypes2.default.object,
 
   /**
    * **Uncontrolled Component:** A default set of values of tokens to be
@@ -424,7 +428,7 @@ Tokenizer.propTypes = {
    *       },
    *     ]
    */
-  defaultValue: _react.PropTypes.array,
+  defaultValue: _propTypes2.default.array,
 
   /**
    * **Controlled Component:** A set of values of tokens to be loaded on
@@ -451,18 +455,18 @@ Tokenizer.propTypes = {
    *       },
    *     ]
    */
-  value: _react.PropTypes.array,
+  value: _propTypes2.default.array,
 
   /**
    * Placeholder text for the typeahead input.
    */
-  placeholder: _react.PropTypes.string,
+  placeholder: _propTypes2.default.string,
 
   /**
    * Event handler triggered whenever the filter is changed and a token
    * is added or removed. Params: `(filter)`
    */
-  onChange: _react.PropTypes.func,
+  onChange: _propTypes2.default.func,
   /**
    * A mapping of datatypes to operators.
    * Resolved by merging with default operators.
@@ -475,7 +479,7 @@ Tokenizer.propTypes = {
    * }
    * ```
    */
-  operators: _react.PropTypes.object
+  operators: _propTypes2.default.object
 };
 Tokenizer.defaultProps = {
   // value: [],

--- a/lib/tokenizer/token.js
+++ b/lib/tokenizer/token.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -93,7 +97,7 @@ var Token = function (_Component) {
 }(_react.Component);
 
 Token.propTypes = {
-  children: _react.PropTypes.object,
-  onRemove: _react.PropTypes.func
+  children: _propTypes2.default.object,
+  onRemove: _propTypes2.default.func
 };
 exports.default = Token;

--- a/lib/typeahead/index.js
+++ b/lib/typeahead/index.js
@@ -14,6 +14,10 @@ var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -353,16 +357,16 @@ var Typeahead = function (_Component) {
 }(_react.Component);
 
 Typeahead.propTypes = {
-  customClasses: _react.PropTypes.object,
-  maxVisible: _react.PropTypes.number,
-  options: _react.PropTypes.array,
-  header: _react.PropTypes.string,
-  datatype: _react.PropTypes.string,
-  defaultValue: _react.PropTypes.string,
-  placeholder: _react.PropTypes.string,
-  onOptionSelected: _react.PropTypes.func,
-  onKeyDown: _react.PropTypes.func,
-  className: _react.PropTypes.string
+  customClasses: _propTypes2.default.object,
+  maxVisible: _propTypes2.default.number,
+  options: _propTypes2.default.array,
+  header: _propTypes2.default.string,
+  datatype: _propTypes2.default.string,
+  defaultValue: _propTypes2.default.string,
+  placeholder: _propTypes2.default.string,
+  onOptionSelected: _propTypes2.default.func,
+  onKeyDown: _propTypes2.default.func,
+  className: _propTypes2.default.string
 };
 Typeahead.defaultProps = {
   options: [],

--- a/lib/typeahead/option.js
+++ b/lib/typeahead/option.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -88,11 +92,11 @@ var TypeaheadOption = function (_Component) {
 }(_react.Component);
 
 TypeaheadOption.propTypes = {
-  customClasses: _react.PropTypes.object,
-  result: _react.PropTypes.string,
-  onClick: _react.PropTypes.func,
-  children: _react.PropTypes.string,
-  hover: _react.PropTypes.bool
+  customClasses: _propTypes2.default.object,
+  result: _propTypes2.default.string,
+  onClick: _propTypes2.default.func,
+  children: _propTypes2.default.string,
+  hover: _propTypes2.default.bool
 };
 TypeaheadOption.defaultProps = {
   customClasses: {},

--- a/lib/typeahead/selector.js
+++ b/lib/typeahead/selector.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _option = require('./option');
 
 var _option2 = _interopRequireDefault(_option);
@@ -164,11 +168,11 @@ var TypeaheadSelector = function (_Component) {
 }(_react.Component);
 
 TypeaheadSelector.propTypes = {
-  options: _react.PropTypes.array,
-  header: _react.PropTypes.string,
-  customClasses: _react.PropTypes.object,
-  selectionIndex: _react.PropTypes.number,
-  onOptionSelected: _react.PropTypes.func
+  options: _propTypes2.default.array,
+  header: _propTypes2.default.string,
+  customClasses: _propTypes2.default.object,
+  selectionIndex: _propTypes2.default.number,
+  onOptionSelected: _propTypes2.default.func
 };
 TypeaheadSelector.defaultProps = {
   selectionIndex: null,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^0.14.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",
+    "prop-types": "^15.0.0",
     "redbox-react": "^1.2.2",
     "rimraf": "^2.5.1",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dom": "^0.14.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",
-    "prop-types": "^15.0.0",
+    "prop-types": "^15.5.7",
     "redbox-react": "^1.2.2",
     "rimraf": "^2.5.1",
     "style-loader": "^0.13.1",
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.5.7"
   },
   "scripts": {
     "example:clean": "rimraf example/dist",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react-dom": "^0.14.0 || ^15.0.0",
+    "prop-types": "^15.6.0"
   },
   "scripts": {
     "example:clean": "rimraf example/dist",

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -1,9 +1,9 @@
 import {
   default as React,
   Component,
-  PropTypes,
 } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import Token from './token';
 import KeyEvent from '../keyevent';
 import Typeahead from '../typeahead';

--- a/src/tokenizer/token.js
+++ b/src/tokenizer/token.js
@@ -1,8 +1,8 @@
 import {
   default as React,
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Encapsulates the rendering of an option that has been "selected" in a

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -3,9 +3,9 @@
 import {
   default as React,
   Component,
-  PropTypes,
 } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
 import fuzzy from 'fuzzy';

--- a/src/typeahead/option.js
+++ b/src/typeahead/option.js
@@ -1,8 +1,8 @@
 import {
   default as React,
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**

--- a/src/typeahead/selector.js
+++ b/src/typeahead/selector.js
@@ -1,8 +1,8 @@
 import {
   default as React,
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
 import TypeaheadOption from './option';
 import classNames from 'classnames';
 


### PR DESCRIPTION
If you use react-structured-filter with React ^15.0.0, it launch this warning:
`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs`

So i used prop-types module to 'propType' component's props.

In the test it still throws the warning, but is a Griddle Warn.